### PR TITLE
Add fpm support

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,23 @@
+name = "FoXy"
+version = "0.0.8"
+author = "Stefano Zaghi"
+copyright = "Copyright © 2016, Stefano Zaghi"
+license = "Multiple licenses"
+description = "Fortran XML parser for poor people"
+maintainer = "Stefano Zaghi"
+homepage = "https://github.com/Fortran-FOSS-Programmers/FoXy"
+
+[library]
+source-dir = "src/lib"
+
+[install]
+library = true
+
+[dependencies]
+[dependencies.StringiFor]
+git = "https://github.com/szaghi/StringiFor"
+rev = "25570c36964ef49942537af942603962c3f26b68"
+
+[dependencies.PENF]
+git = "https://github.com/szaghi/PENF"
+rev = "65061235982495b158412b70c05b228af4320d94"


### PR DESCRIPTION
- [x] Add fpm support.

PS. In the `FoXy` source code, **only the `PENF` and `StringiFor` modules are explicitly used, which are declared in `fpm.toml` now**, while `FACE` and `BeFoR64` are the dependencies of `StringiFor`, which have been declared in [`fpm.toml` of `StringiFor`](https://github.com/szaghi/StringiFor/commit/cc776cb73419ef511addfb8877567b8285418028).

Hope to get your review @szaghi , thanks again!
Zhihua