### PR TITLE
Fix a bug in the file src/lib/CMakeLists.txt

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -11,7 +11,7 @@ set(LIB FoXy)
 add_library(${LIB}
         foxy.f90
         foxy_xml_file.f90
-        foxy_xml_tag.f90
+        foxy_xml_tag.F90
         )
 add_library(${NAMESPACE}${LIB} ALIAS ${LIB})
 target_link_libraries(${LIB} PENF::PENF FACE::FACE BeFoR64::BeFoR64 StringiFor::StringiFor)


### PR DESCRIPTION
At line 11, foxy_xml_tag.f90 is changed to foxy_xml_tag.F90.
This led to an error when compiling with cmake.